### PR TITLE
Fix typos in comments, docstrings, and log messages

### DIFF
--- a/src/runathena/runAthena.py
+++ b/src/runathena/runAthena.py
@@ -848,7 +848,7 @@ if not postprocess:
                     break
             # check
             if tmpSetupDir is None:
-                print ("ERROR : cound not find setup.py in %s" % dbrFile)
+                print ("ERROR : could not find setup.py in %s" % dbrFile)
                 EC_DBRelease.exit()
             # run setup.py
             dbrSetupStr  = "import os\nos.chdir('%s')\nexec(open('setup.py').read())\nprint ('DBR setup finished')\nos.chdir('%s')\n" % \

--- a/src/runmerge/fs_copy
+++ b/src/runmerge/fs_copy
@@ -58,7 +58,7 @@ def get_adler32sum(fname):
             cksum = zlib.adler32(d, cksum)
     f.close()
 
-    # remove the tailing 'L' charactor
+    # remove the tailing 'L' character
     cksum_str = re.sub(r'L$','', hex(cksum & 0xffffffff) )
 
     return cksum_str
@@ -309,10 +309,10 @@ if __name__ == '__main__':
             time.sleep(wait_time)
 
         ## compose copy command
-        ##  - timeout is increasd for each trial
+        ##  - timeout is increased for each trial
         copy_cmd = make_copycmd(protocol, vo, timeout*cnt_trial, src_surl, dest_surl)
 
-        ## faile to compose the full copy command, give another try for the whole loop
+        ## failed to compose the full copy command, give another try for the whole loop
         if not copy_cmd:
             printError('fail to compose copy command', errfile)
             continue

--- a/src/runmerge/merge_trf_pre.py
+++ b/src/runmerge/merge_trf_pre.py
@@ -10,7 +10,7 @@ streamNames = []
 try:
     streamNames = inputFileSummary['stream_names']
 except KeyError:
-    logPreInclude.warning('cannot find stream names - unable to determin POOL format, assuming format "AOD"')
+    logPreInclude.warning('cannot find stream names - unable to determine POOL format, assuming format "AOD"')
 
 logPreInclude.info('file_type   : %s' % inputFileSummary['file_type'])
 logPreInclude.info('steam names : %s' % streamNames)

--- a/src/runmerge/runMerge.py
+++ b/src/runmerge/runMerge.py
@@ -461,7 +461,7 @@ def __run_merge__(inputType, inputFiles, outputFile, cmdEnvSetup='', userCmd=Non
 
 def __replace_IN_OUT_arguments__(arg_str, inputFiles, outputFile):
     '''
-    replace %IN and %OUT withh proper values
+    replace %IN and %OUT with proper values
     '''
 
     arg_str_new = arg_str.replace('%IN', '"%s"' % (','.join( inputFiles )) ).replace( '%OUT', '"%s"' % outputFile )


### PR DESCRIPTION
Found while searching for similar issues to the `algJSON`/`argJSON` typo fixed in #55.

All changes are in comments, docstrings, or one-off user-facing messages — no logic is affected.

| File | Line | Fix |
|---|---|---|
| `src/runmerge/fs_copy` | 61 | `charactor` → `character` |
| `src/runmerge/fs_copy` | 312 | `increasd` → `increased` |
| `src/runmerge/fs_copy` | 315 | `faile` → `failed` |
| `src/runmerge/runMerge.py` | 464 | `withh` → `with` |
| `src/runmerge/merge_trf_pre.py` | 13 | `determin` → `determine` |
| `src/runathena/runAthena.py` | 851 | `cound` → `could` |

Note: `ACERMC TERMINATES NORMALY` in `runAthena.py:1471` was intentionally left as-is — it matches AcerMC's actual output string inside a `re.search()` call.